### PR TITLE
Fixes for type params and higher kinds

### DIFF
--- a/src/test/scala/dataclass/OneFieldTests.scala
+++ b/src/test/scala/dataclass/OneFieldTests.scala
@@ -3,6 +3,8 @@ package dataclass
 import shapeless.test.illTyped
 import utest._
 
+import scala.concurrent.Future
+
 object OneFieldTests extends TestSuite {
   val tests = Tests {
     @data class Foo(a: Int)
@@ -103,6 +105,56 @@ object OneFieldTests extends TestSuite {
         assert(false)
       } catch {
         case _: IndexOutOfBoundsException =>
+      }
+    }
+
+    "type params" - {
+      "one" - {
+        "used" - {
+          @data class Bar[T](t: T)
+          val barI = Bar[Int](2)
+          val barI2 = Bar[Int](3)
+          val barI3 = Bar[Int](2)
+          val barS = Bar[String]("ab")
+          assert(barI != barS)
+          assert(barI != barI2)
+          assert(barI == barI3)
+        }
+
+        "unused" - {
+          @data class Bar[T](n: Int)
+          val barI = Bar[Int](2)
+          val barI2 = Bar[Int](3)
+          val barI3 = Bar[Int](2)
+          val barS = Bar[String](4)
+          val barS2 = Bar[String](2)
+          assert(barI != barS)
+          assert(barI != barI2)
+          assert(barI == barI3)
+          assert(barS != barS2)
+          assert(barI == barS2)
+        }
+      }
+
+      "two" - {
+        @data class Bar[T, U](u: U)
+        val barI = Bar[Int, Double](1.0)
+        val barS = Bar[String, Long](2L)
+        assert(barI != barS)
+      }
+
+      "three" - {
+        @data class Bar[T, U, V](v: V)
+        val barI = Bar[Int, Double, Int](2)
+        val barS = Bar[String, Long, Long](3L)
+        assert(barI != barS)
+      }
+
+      "higher kind" - {
+        @data class Bar[F[_]](f: F[Int])
+        val barF = Bar[Future](Future.successful(2))
+        val barL = Bar[List](List(3))
+        assert(barF != barL)
       }
     }
   }

--- a/src/test/scala/dataclass/ZeroFieldTests.scala
+++ b/src/test/scala/dataclass/ZeroFieldTests.scala
@@ -3,6 +3,8 @@ package dataclass
 import shapeless.test.illTyped
 import utest._
 
+import scala.concurrent.Future
+
 object ZeroFieldTests extends TestSuite {
   val tests = Tests {
     @data class Foo()
@@ -21,6 +23,36 @@ object ZeroFieldTests extends TestSuite {
       val foo = Foo()
       val t = foo.tuple
       assert(t == ())
+    }
+
+    "type params" - {
+      "one" - {
+        @data class Bar[T]()
+        val barI = Bar[Int]()
+        val barS = Bar[String]()
+        assert(barI == barS) // type erasure, both instances are the same at runtime
+      }
+
+      "two" - {
+        @data class Bar[T, U]()
+        val barI = Bar[Int, Double]()
+        val barS = Bar[String, Long]()
+        assert(barI == barS) // type erasure, both instances are the same at runtime
+      }
+
+      "three" - {
+        @data class Bar[T, U, V]()
+        val barI = Bar[Int, Double, Int]()
+        val barS = Bar[String, Long, Long]()
+        assert(barI == barS) // type erasure, both instances are the same at runtime
+      }
+
+      "higher kind" - {
+        @data class Bar[F[_]]()
+        val barF = Bar[Future]()
+        val barL = Bar[List]()
+        assert(barF == barL) // type erasure, both instances are the same at runtime
+      }
     }
 
     "class constructor is private" - {


### PR DESCRIPTION
Not sure having type params with kinds other than `*` and `* -> *` works fine yet.