### PR TITLE
Make generated `tuple` method private

### DIFF
--- a/src/main/scala/dataclass/Macros.scala
+++ b/src/main/scala/dataclass/Macros.scala
@@ -173,13 +173,13 @@ private[dataclass] class Macros(val c: Context) extends ImplTransformers {
           val tupleMethod =
             if (hasTuple || allParams.lengthCompare(22) > 0) Nil
             else if (allParams.isEmpty)
-              Seq(q"def tuple = ()")
+              Seq(q"private def tuple = ()")
             else {
               definitions.TupleClass.seq
               val fields = allParams.map(p => q"this.${p.name}")
               val tupleName = TermName(s"Tuple${allParams.length}")
               Seq(
-                q"def tuple = _root_.scala.$tupleName(..$fields)"
+                q"private def tuple = _root_.scala.$tupleName(..$fields)"
               )
             }
 

--- a/src/test/scala/dataclass/MoreFieldsTests.scala
+++ b/src/test/scala/dataclass/MoreFieldsTests.scala
@@ -11,9 +11,11 @@ object MoreFieldsTests extends TestSuite {
           s: String,
           b: Boolean = true,
           d: Double = 1.0
-      )
+      ) {
+        def tuple0 = tuple
+      }
       val foo = Bar(1, "a", false, 1.2)
-      val t = foo.tuple
+      val t = foo.tuple0
       assert(t == (1, "a", false, 1.2))
     }
 

--- a/src/test/scala/dataclass/OneFieldTests.scala
+++ b/src/test/scala/dataclass/OneFieldTests.scala
@@ -43,8 +43,11 @@ object OneFieldTests extends TestSuite {
     }
 
     "tuple" - {
-      val foo = Foo(1)
-      val t = foo.tuple
+      @data class Foo0(a: Int) {
+        def tuple0 = tuple
+      }
+      val foo = Foo0(1)
+      val t = foo.tuple0
       assert(t == Tuple1(1))
     }
 

--- a/src/test/scala/dataclass/TwoFieldsTests.scala
+++ b/src/test/scala/dataclass/TwoFieldsTests.scala
@@ -55,8 +55,11 @@ object TwoFieldsTests extends TestSuite {
     }
 
     "tuple" - {
-      val foo = Foo(1, "a")
-      val t = foo.tuple
+      @data class Foo0(a: Int, other: String) {
+        def tuple0 = tuple
+      }
+      val foo = Foo0(1, "a")
+      val t = foo.tuple0
       assert(t == (1, "a"))
     }
 

--- a/src/test/scala/dataclass/ZeroFieldTests.scala
+++ b/src/test/scala/dataclass/ZeroFieldTests.scala
@@ -20,9 +20,22 @@ object ZeroFieldTests extends TestSuite {
       assert(str == expected)
     }
     "tuple" - {
-      val foo = Foo()
-      val t = foo.tuple
-      assert(t == ())
+      @data class Foo0() {
+        def tuple0 = tuple
+      }
+
+      * - {
+        val foo = Foo0()
+        val t = foo.tuple0
+        assert(t == ())
+      }
+
+      "actually private" - {
+        val foo = Foo0()
+        illTyped("""
+          foo.tuple
+        """, "method tuple in class Foo0 cannot be accessed in Foo0")
+      }
     }
 
     "type params" - {


### PR DESCRIPTION
So that it can still be helpful in the class body, but isn't part of its public API.