### PR TITLE
Implement reference equality like case classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
 target/
-.idea/
-.bsp/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target/
+.idea/
+.bsp/

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ final class Foo(val n: Int, val s: String) extends Product with Serializable {
   }
 
   override def canEqual(obj: Any): Boolean = obj != null && obj.isInstanceOf[Foo]
-  override def equals(obj: Any): Boolean = canEqual(obj) && {
+  override def equals(obj: Any): Boolean = (this.eq(obj.asInstanceOf[AnyRef])) || canEqual(obj) && {
     val other = obj.asInstanceOf[Foo]
     n == other.n && s == other.s
   })

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ final class Foo(val n: Int, val s: String) extends Product with Serializable {
   }
 
   override def canEqual(obj: Any): Boolean = obj != null && obj.isInstanceOf[Foo]
-  override def equals(obj: Any): Boolean = (this.eq(obj.asInstanceOf[AnyRef])) || canEqual(obj) && {
+  override def equals(obj: Any): Boolean = this.eq(obj.asInstanceOf[AnyRef]) || canEqual(obj) && {
     val other = obj.asInstanceOf[Foo]
     n == other.n && s == other.s
   })

--- a/src/main/scala/dataclass/Macros.scala
+++ b/src/main/scala/dataclass/Macros.scala
@@ -161,7 +161,7 @@ private[dataclass] class Macros(val c: Context) extends ImplTransformers {
                """,
               q"""
                 override def equals(obj: Any): _root_.scala.Boolean =
-                  canEqual(obj) && {
+                  (this.eq(obj.asInstanceOf[AnyRef])) || canEqual(obj) && {
                     val other = obj.asInstanceOf[$tpname[..$wildcardedTparams]]
                     $fldChecks
                   }

--- a/src/main/scala/dataclass/Macros.scala
+++ b/src/main/scala/dataclass/Macros.scala
@@ -161,7 +161,7 @@ private[dataclass] class Macros(val c: Context) extends ImplTransformers {
                """,
               q"""
                 override def equals(obj: Any): _root_.scala.Boolean =
-                  (this.eq(obj.asInstanceOf[AnyRef])) || canEqual(obj) && {
+                  this.eq(obj.asInstanceOf[AnyRef]) || canEqual(obj) && {
                     val other = obj.asInstanceOf[$tpname[..$wildcardedTparams]]
                     $fldChecks
                   }

--- a/src/test/scala/dataclass/OneFieldTests.scala
+++ b/src/test/scala/dataclass/OneFieldTests.scala
@@ -5,6 +5,7 @@ import shapeless.test.illTyped
 import utest._
 
 import scala.concurrent.Future
+import scala.util.Random
 
 object OneFieldTests extends TestSuite {
   val tests = Tests {
@@ -20,6 +21,19 @@ object OneFieldTests extends TestSuite {
         val foo2 = Foo(3)
         assert(foo != foo2)
       }
+    }
+    "reference equals" - {
+      class Crazy() {
+        var i = -1
+        override def equals(obj: Any): Boolean = { i+=1; i % 2 == 0 }
+      }
+      @data class FooCrazy(count: Crazy)
+      val crazy = new Crazy()
+      val foo = FooCrazy(crazy)
+      assert(crazy == crazy)
+      assert(crazy != crazy)
+      assert(foo == foo)
+      assert(foo == foo)
     }
     "toString" - {
       val foo = Foo(1)

--- a/src/test/scala/dataclass/OneFieldTests.scala
+++ b/src/test/scala/dataclass/OneFieldTests.scala
@@ -5,7 +5,6 @@ import shapeless.test.illTyped
 import utest._
 
 import scala.concurrent.Future
-import scala.util.Random
 
 object OneFieldTests extends TestSuite {
   val tests = Tests {

--- a/src/test/scala/dataclass/OneFieldTests.scala
+++ b/src/test/scala/dataclass/OneFieldTests.scala
@@ -25,7 +25,7 @@ object OneFieldTests extends TestSuite {
     "reference equals" - {
       class Crazy() {
         var i = -1
-        override def equals(obj: Any): Boolean = { i+=1; i % 2 == 0 }
+        override def equals(obj: Any): Boolean = { i += 1; i % 2 == 0 }
       }
       @data class FooCrazy(count: Crazy)
       val crazy = new Crazy()


### PR DESCRIPTION
For `case class Ola` this is the result of `scalac -print`

```
override <synthetic> def equals(x$1: Object): Boolean = Ola.this.eq(x$1).||({
  case <synthetic> val x1: Object = x$1;
  case5(){
    if (x1.$isInstanceOf[dataclass.Ola]())
      matchEnd4(true)
    else
      case6()
  };
  case6(){
    matchEnd4(false)
  };
  matchEnd4(x: Boolean){
    x
  }
}.&&({
      <synthetic> val Ola$1: dataclass.Ola = x$1.$asInstanceOf[dataclass.Ola]();
      Ola.this.foo().==(Ola$1.foo()).&&(Ola$1.canEqual(Ola.this))
    }));
    def <init>(foo: Int): dataclass.Ola = {
      Ola.this.foo = foo;
      Ola.super.<init>();
      Ola.super./*Product*/$init$();
      ()
    }
  };
```

So I tried to move the reference equality check as the first thing, but had do do that cast...